### PR TITLE
feat: load db connection string from environment if it is not set in the config file

### DIFF
--- a/Conflux.API/appsettings.json
+++ b/Conflux.API/appsettings.json
@@ -6,5 +6,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "Cors": {
+    "AllowedOrigins": [
+      "*"
+    ]
+  }
 }

--- a/Conflux.Data.Tests/ConfluxContextFactoryTests.cs
+++ b/Conflux.Data.Tests/ConfluxContextFactoryTests.cs
@@ -1,0 +1,55 @@
+﻿// This program has been developed by students from the bachelor Computer Science at Utrecht
+// University within the Software Project course.
+// 
+// © Copyright Utrecht University (Department of Information and Computing Sciences)
+
+namespace Conflux.Data.Tests;
+
+public class ConfluxContextFactoryTests : IDisposable
+{
+    private readonly string? _originalHost;
+    private readonly string? _originalName;
+    private readonly string? _originalPassword;
+    private readonly string? _originalPort;
+    private readonly string? _originalUser;
+
+    public ConfluxContextFactoryTests()
+    {
+        // Store original environment variables
+        _originalHost = Environment.GetEnvironmentVariable("DB_HOST");
+        _originalPort = Environment.GetEnvironmentVariable("DB_PORT");
+        _originalName = Environment.GetEnvironmentVariable("DB_NAME");
+        _originalUser = Environment.GetEnvironmentVariable("DB_USER");
+        _originalPassword = Environment.GetEnvironmentVariable("DB_PASSWORD");
+
+        // Set test environment variables
+        Environment.SetEnvironmentVariable("DB_HOST", "testhost");
+        Environment.SetEnvironmentVariable("DB_PORT", "1234");
+        Environment.SetEnvironmentVariable("DB_NAME", "testdb");
+        Environment.SetEnvironmentVariable("DB_USER", "testuser");
+        Environment.SetEnvironmentVariable("DB_PASSWORD", "testpassword");
+    }
+
+    public void Dispose()
+    {
+        // Restore original environment variables
+        Environment.SetEnvironmentVariable("DB_HOST", _originalHost);
+        Environment.SetEnvironmentVariable("DB_PORT", _originalPort);
+        Environment.SetEnvironmentVariable("DB_NAME", _originalName);
+        Environment.SetEnvironmentVariable("DB_USER", _originalUser);
+        Environment.SetEnvironmentVariable("DB_PASSWORD", _originalPassword);
+    }
+
+    [Fact]
+    public void GetConnectionStringFromEnvironment_ReturnsCorrectConnectionString()
+    {
+        // Arrange
+        string expected = "Host=testhost:1234;Database=testdb;Username=testuser;Password=testpassword";
+
+        // Act
+        string actual = ConfluxContextFactory.GetConnectionStringFromEnvironment();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/Conflux.Data/ConfluxContextFactory.cs
+++ b/Conflux.Data/ConfluxContextFactory.cs
@@ -32,10 +32,28 @@ public class ConfluxContextFactory : IDesignTimeDbContextFactory<ConfluxContext>
             .Build();
 
         string? connectionString = config.GetConnectionString("Database");
+        if (string.IsNullOrEmpty(connectionString))
+            // If the connection string is not found in the configuration, use environment variables
+            connectionString = GetConnectionStringFromEnvironment();
 
         DbContextOptionsBuilder<ConfluxContext> optionsBuilder = new();
         optionsBuilder.UseNpgsql(connectionString);
 
         return new(optionsBuilder.Options);
+    }
+
+    /// <summary>
+    /// Gets the connection string from environment variables.
+    /// </summary>
+    /// <returns>The connection string.</returns>
+    public static string GetConnectionStringFromEnvironment()
+    {
+        string? host = Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost";
+        string? port = Environment.GetEnvironmentVariable("DB_PORT") ?? "5432";
+        string? database = Environment.GetEnvironmentVariable("DB_NAME");
+        string? user = Environment.GetEnvironmentVariable("DB_USER");
+        string? password = Environment.GetEnvironmentVariable("DB_PASSWORD");
+
+        return $"Host={host}:{port};Database={database};Username={user};Password={password}";
     }
 }

--- a/Conflux.RepositoryConnections.NWOpen/Conflux.RepositoryConnections.NWOpen.csproj
+++ b/Conflux.RepositoryConnections.NWOpen/Conflux.RepositoryConnections.NWOpen.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NWOpen.Net" Version="1.1.0" />
+        <PackageReference Include="NWOpen.Net" Version="1.1.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Conflux.RepositoryConnections.NWOpen/TemporaryProjectRetriever.cs
+++ b/Conflux.RepositoryConnections.NWOpen/TemporaryProjectRetriever.cs
@@ -3,7 +3,6 @@
 // 
 // © Copyright Utrecht University (Department of Information and Computing Sciences)
 
-using Microsoft.Extensions.Logging;
 using NWOpen.Net.Models;
 using NWOpen.Net.Services;
 

--- a/Conflux.RepositoryConnections.Tests/Conflux.RepositoryConnections.Tests.csproj
+++ b/Conflux.RepositoryConnections.Tests/Conflux.RepositoryConnections.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="NWOpen.Net" Version="1.1.0" />
+        <PackageReference Include="NWOpen.Net" Version="1.1.0"/>
         <PackageReference Include="xunit.assert" Version="2.9.3"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">


### PR DESCRIPTION
## Description
Instead of crashing when no database connection string is provided, instead attempt to load it from the environment. This also helps with our deployment.

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
