### PR TITLE
fix: orcid link formatting

### DIFF
--- a/Conflux.API/Conflux.API.csproj
+++ b/Conflux.API/Conflux.API.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="NSwag.CodeGeneration.TypeScript" Version="14.4.0" />
         <PackageReference Include="oqo0.SwaggerThemes" Version="1.4.3"/>
         <PackageReference Include="ORCID.Net" Version="1.3.0" />
-        <PackageReference Include="RAiD.Net" Version="1.3.0" />
+        <PackageReference Include="RAiD.Net" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Conflux.API/Controllers/OrcidController.cs
+++ b/Conflux.API/Controllers/OrcidController.cs
@@ -85,7 +85,7 @@ public class OrcidController : ControllerBase
             return BadRequest("User session does not contain a user");
 
         // Hardcoded ORCID - likely for testing/dev only
-        const string exampleOrcid = "0000-0002-1825-0097";
+        const string exampleOrcid = "https://orcid.org/0000-0002-1825-0097";
 
         // If SRAM is enabled (but OrcidAuthentication feature flag is off), update DB with hardcoded ORCID.
         // This still needs the fix to avoid the DbUpdateException.
@@ -243,7 +243,7 @@ public class OrcidController : ControllerBase
             return NotFound("User does not have an associated Person record.");
         }
         
-        dbUser.Person.ORCiD = orcidId;
+        dbUser.Person.ORCiD = $"https://orcid.org/{orcidId}";
         try
         {
             await _context.SaveChangesAsync();

--- a/Conflux.Integrations.RAiD/Conflux.Integrations.RAiD.csproj
+++ b/Conflux.Integrations.RAiD/Conflux.Integrations.RAiD.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="RAiD.Net" Version="1.3.0" />
+        <PackageReference Include="RAiD.Net" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## YouTrack tasks
N/A 

## Description
Fix issue where orcids were not properly formatted when linked and this results in unmintable projects.

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
- [x] All endpoints have the proper access control attributes
