### PR TITLE
feat: add incompatibility for no position in contributor

### DIFF
--- a/Conflux.Integrations.RAiD/ProjectMapperService.cs
+++ b/Conflux.Integrations.RAiD/ProjectMapperService.cs
@@ -165,6 +165,14 @@ public class ProjectMapperService : IProjectMapperService
         // Constraints: contributors must have one and only one position at any given time (contributors may also be flagged as a 'leader' or 'contact' separately)
         // Source: https://metadata.raid.org/en/latest/core/contributors.html#contributor-position
         incompatibilities.AddRange(project.Contributors
+            .Where(c => c.Positions.Count == 0)
+            .Select(c => new RAiDIncompatibility
+            {
+                Type = RAiDIncompatibilityType.ContributorWithoutPosition,
+                ObjectId = c.PersonId,
+            }));
+        
+        incompatibilities.AddRange(project.Contributors
             .Where(c =>
             {
                 if (c.Positions.Count == 0)

--- a/Conflux.Integrations.RAiD/RAiDIncompatibility.cs
+++ b/Conflux.Integrations.RAiD/RAiDIncompatibility.cs
@@ -16,6 +16,7 @@ public enum RAiDIncompatibilityType
     NoContributors,
     ContributorWithoutOrcid,
     OverlappingContributorPositions,
+    ContributorWithoutPosition,
     NoProjectLeader,
     NoProjectContact,
     OrganisationWithoutRor,


### PR DESCRIPTION
## Description
Add incompatibility for when a contributor has no position. 

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
- [x] All endpoints have the proper access control attributes
