### PR TITLE
perf: improve performance of get all projects endpoint

### DIFF
--- a/Conflux.API/Program.cs
+++ b/Conflux.API/Program.cs
@@ -109,9 +109,8 @@ public class Program
         builder.Services.AddScoped<IAccessControlService, AccessControlService>();
         builder.Services.AddScoped<ITimelineService, TimelineService>();
         builder.Services.AddScoped<IAdminService, AdminService>();
-        builder.Services.AddScoped<ILanguageService, LanguageService>();
-
-        builder.Services.AddScoped<IEmbeddingService, OnnxEmbeddingService>();
+        builder.Services.AddSingleton<ILanguageService, LanguageService>();
+        builder.Services.AddSingleton<IEmbeddingService, OnnxEmbeddingService>();
 
 
         if (await featureManager.IsEnabledAsync("OrcidIntegration"))


### PR DESCRIPTION
## YouTrack tasks
CX-335

## Description
- Improve loading times for the get all projects endpoint by reducing the complexity of the query
- Reduce memory usage of the whole application by making the embedding service and the language service singletons
- Also more importantly, this keeps the production env from killing itself because it's out of memory.
<img width="736" alt="image" src="https://github.com/user-attachments/assets/384b8825-1f04-4f4e-8fb4-81747e1ee9f4" />


## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
- [x] All endpoints have the proper access control attributes
