### PR TITLE
fix: sram contributor sync

### DIFF
--- a/Conflux.Domain.Logic/Services/ContributorsService.cs
+++ b/Conflux.Domain.Logic/Services/ContributorsService.cs
@@ -190,11 +190,13 @@ public class ContributorsService : IContributorsService
         Contributor contributor = _context.Contributors
                 .Include(c => c.Roles)
                 .Include(c => c.Person)
+                .ThenInclude(p => p.User)
+                .ThenInclude(user => user.Roles)
                 .Include(c => c.Positions)
                 .SingleOrDefault(p => p.ProjectId == projectId && p.PersonId == personId) ??
             throw new ContributorNotFoundException(projectId);
-        
-        if (contributor.Person?.UserId != null) 
+
+        if (contributor.Person is { UserId: not null, User: not null } && contributor.Person.User.Roles.Any(r => r.ProjectId == projectId && r.Type == UserRoleType.Contributor))
             throw new ContributorHasUserException("Cannot delete contributor with a user account.");
 
         _context.Contributors.Remove(contributor);

--- a/Conflux.Domain.Logic/Services/SRAMProjectSyncService.cs
+++ b/Conflux.Domain.Logic/Services/SRAMProjectSyncService.cs
@@ -75,8 +75,6 @@ public class SRAMProjectSyncService : ISRAMProjectSyncService
                 Person = person,
                 Roles = [],
             };
-         
-            
             
             newUsers.Add(newUser);
             newPeople.Add(person);
@@ -155,11 +153,19 @@ public class SRAMProjectSyncService : ISRAMProjectSyncService
         
         // For each contributor with a user associated, check if they have the contributor role
         foreach (Contributor contributor in project.Contributors
-                     .Where(c => c.Person?.User != null))
+            .Where(c => c.Person?.User != null).ToList())
         {
             // if they no longer have the contributor role, end all their positions 
             if (contributor.Person!.User!.Roles.Any(r => r.Type == UserRoleType.Contributor && r.ProjectId == project.Id))
                 continue;
+            
+            // if they have not had any positions, remove the contributor
+            if (!contributor.Positions.Any())
+            {
+                project.Contributors.Remove(contributor);
+                _confluxContext.Contributors.Remove(contributor);
+                continue;
+            }
             
             // End all positions
             foreach (ContributorPosition position in contributor.Positions.Where(p => p.EndDate == null))


### PR DESCRIPTION
## Description
- Fix issues with sram contributor sync
- Make a contributor with a user attached deletable if they are no longer in the sram group.

## Side Effects
- If a user has not had any positions and is removed from the contributor group in sram the contributor is automatically deleted.

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
- [x] All endpoints have the proper access control attributes
