### PR TITLE
fix: user session data being cached erroneously

### DIFF
--- a/Conflux.API.Tests/Controllers/UserSessionControllerTests.cs
+++ b/Conflux.API.Tests/Controllers/UserSessionControllerTests.cs
@@ -4,6 +4,7 @@
 // © Copyright Utrecht University (Department of Information and Computing Sciences)
 
 using Conflux.API.Controllers;
+using Conflux.Domain;
 using Conflux.Domain.Logic.DTOs.Responses;
 using Conflux.Domain.Logic.Services;
 using Conflux.Domain.Session;
@@ -35,8 +36,7 @@ public class UserSessionControllerTests
             Name = "Test User",
         };
 
-        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync(userSession);
-        mockUserSessionService.Setup(s => s.UpdateUser()).ReturnsAsync(userSession);
+        mockUserSessionService.Setup(s => s.GetSession()).ReturnsAsync(userSession);
 
         string[] allowedRedirects = ["https://valid.example.com"];
         var mockConfigSection = new Mock<IConfigurationSection>();
@@ -72,7 +72,7 @@ public class UserSessionControllerTests
         var mockFeatureManager = new Mock<IVariantFeatureManager>();
         var mockConfiguration = new Mock<IConfiguration>();
 
-        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync((UserSession)null!);
+        mockUserSessionService.Setup(s => s.GetSession()).ReturnsAsync((UserSession)null!);
 
         string[] allowedRedirects = ["https://valid.example.com"];
         var mockConfigSection = new Mock<IConfigurationSection>();
@@ -113,8 +113,7 @@ public class UserSessionControllerTests
             Name = "Test User",
         };
 
-        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync(userSession);
-        mockUserSessionService.Setup(s => s.UpdateUser()).ReturnsAsync(userSession);
+        mockUserSessionService.Setup(s => s.GetSession()).ReturnsAsync(userSession);
 
         string[] allowedRedirects = ["https://valid.example.com"];
         var mockConfigSection = new Mock<IConfigurationSection>();
@@ -287,11 +286,28 @@ public class UserSessionControllerTests
 
         UserSession userSession = new()
         {
+            UserId = Guid.CreateVersion7(),
             Email = "test@example.com",
             Name = "Test User",
         };
 
-        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync(userSession);
+        User user = new()
+        {
+            Id = userSession.UserId,
+            SRAMId = "test-sram-id",
+            SCIMId = "test-scim-id",
+            PersonId = Guid.CreateVersion7(),
+            Roles = new List<UserRole>(),
+            PermissionLevel = PermissionLevel.User,
+            AssignedLectorates = new List<string>(),
+            AssignedOrganisations = new List<string>(),
+            RecentlyAccessedProjectIds = new List<Guid>(),
+            FavoriteProjectIds = new List<Guid>(),
+            Person = null
+        };
+
+        mockUserSessionService.Setup(s => s.GetSession()).ReturnsAsync(userSession);
+        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync(user);
 
         // Set up configuration
         string[] allowedRedirects = ["https://valid.example.com"];
@@ -330,7 +346,24 @@ public class UserSessionControllerTests
         var mockFeatureManager = new Mock<IVariantFeatureManager>();
         var mockConfiguration = new Mock<IConfiguration>();
 
-        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync((UserSession)null!);
+        mockUserSessionService.Setup(s => s.GetSession()).ReturnsAsync((UserSession)null!);
+        
+    
+        var user = new User
+        {
+            Id = Guid.CreateVersion7(),
+            SRAMId = "test-sram-id",
+            SCIMId = "test-scim-id",
+            PersonId = Guid.CreateVersion7(),
+            Roles = new List<UserRole>(),
+            PermissionLevel = PermissionLevel.User,
+            AssignedLectorates = new List<string>(),
+            AssignedOrganisations = new List<string>(),
+            RecentlyAccessedProjectIds = new List<Guid>(),
+            FavoriteProjectIds = new List<Guid>(),
+            Person = null
+        };
+        mockUserSessionService.Setup(s => s.GetUser()).ReturnsAsync(user);
 
         // Set up configuration
         string[] allowedRedirects = ["https://valid.example.com"];

--- a/Conflux.API.Tests/Filters/AccessControlFilterTests.cs
+++ b/Conflux.API.Tests/Filters/AccessControlFilterTests.cs
@@ -6,6 +6,7 @@
 using Conflux.API.Attributes;
 using Conflux.API.Filters;
 using Conflux.Domain;
+using Conflux.Domain.Logic.Exceptions;
 using Conflux.Domain.Logic.Services;
 using Conflux.Domain.Session;
 using Microsoft.AspNetCore.Http;
@@ -50,7 +51,7 @@ public class AccessControlFilterTests
     {
         // Arrange
         var userSessionService = new Mock<IUserSessionService>();
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync((UserSession?)null);
+        userSessionService.Setup(x => x.GetUser()).Throws(new UserNotAuthenticatedException());
 
         var accessControlService = new Mock<IAccessControlService>();
         AccessControlFilter filter = new(userSessionService.Object, accessControlService.Object, UserRoleType.Admin);
@@ -63,11 +64,7 @@ public class AccessControlFilterTests
         };
         AuthorizationFilterContext context = new(actionContext, new List<IFilterMetadata>());
 
-        // Act
-        await filter.OnAuthorizationAsync(context);
-
-        // Assert
-        Assert.IsType<UnauthorizedResult>(context.Result);
+        await Assert.ThrowsAsync<UserNotAuthenticatedException>(() => filter.OnAuthorizationAsync(context));
     }
 
     [Fact]
@@ -78,12 +75,15 @@ public class AccessControlFilterTests
         Guid projectId = Guid.CreateVersion7();
 
         var userSessionService = new Mock<IUserSessionService>();
+        User user = CreateUserWithPerson(userId, "Test User", "test-scim-id");
         UserSession userSession = new()
         {
-            User = CreateUserWithPerson(userId, "Test User", "test-scim-id"),
+            UserId = userId,
             Collaborations = new(),
         };
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetSession()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(user);
+
 
         var accessControlService = new Mock<IAccessControlService>();
         accessControlService.Setup(x => x.UserHasRoleInProject(userId, projectId, UserRoleType.Admin))
@@ -124,12 +124,15 @@ public class AccessControlFilterTests
         Guid projectId = Guid.CreateVersion7();
 
         var userSessionService = new Mock<IUserSessionService>();
+        User user = CreateUserWithPerson(userId, "Test User", "test-scim-id");
         UserSession userSession = new()
         {
-            User = CreateUserWithPerson(userId, "Test User", "test-scim-id"),
+            UserId = userId,
             Collaborations = new(),
         };
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetSession()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(user);
+
 
         var accessControlService = new Mock<IAccessControlService>();
         accessControlService.Setup(x => x.UserHasRoleInProject(userId, projectId, UserRoleType.Admin))
@@ -172,12 +175,14 @@ public class AccessControlFilterTests
         Guid userId = Guid.CreateVersion7();
 
         var userSessionService = new Mock<IUserSessionService>();
+        User user = CreateUserWithPerson(userId, "Test User", "test-scim-id");
         UserSession userSession = new()
         {
-            User = CreateUserWithPerson(userId, "Test User", "test-scim-id"),
+            UserId = userId,
             Collaborations = new(),
         };
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetSession()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(user);
 
         var accessControlService = new Mock<IAccessControlService>();
         accessControlService.Setup(x => x.UserHasRoleInProject(
@@ -217,12 +222,14 @@ public class AccessControlFilterTests
         Guid userId = Guid.CreateVersion7();
 
         var userSessionService = new Mock<IUserSessionService>();
+        User user = CreateUserWithPerson(userId, "Test User", "test-scim-id");
         UserSession userSession = new()
         {
-            User = CreateUserWithPerson(userId, "Test User", "test-scim-id"),
+            UserId = userId,
             Collaborations = new(),
         };
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetSession()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(user);
 
         var accessControlService = new Mock<IAccessControlService>();
         AccessControlFilter filter = new(userSessionService.Object, accessControlService.Object, UserRoleType.Admin);
@@ -258,12 +265,14 @@ public class AccessControlFilterTests
         Guid userId = Guid.CreateVersion7();
 
         var userSessionService = new Mock<IUserSessionService>();
+        User user = CreateUserWithPerson(userId, "Test User", "test-scim-id");
         UserSession userSession = new()
         {
-            User = CreateUserWithPerson(userId, "Test User", "test-scim-id"),
+            UserId = userId,
             Collaborations = new(),
         };
-        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetSession()).ReturnsAsync(userSession);
+        userSessionService.Setup(x => x.GetUser()).ReturnsAsync(user);
 
         var accessControlService = new Mock<IAccessControlService>();
         AccessControlFilter filter = new(userSessionService.Object, accessControlService.Object, UserRoleType.Admin);

--- a/Conflux.API.Tests/Filters/AuthorizationFilterTests.cs
+++ b/Conflux.API.Tests/Filters/AuthorizationFilterTests.cs
@@ -4,6 +4,7 @@
 // © Copyright Utrecht University (Department of Information and Computing Sciences)
 
 using Conflux.API.Attributes;
+using Conflux.Domain;
 using Conflux.Domain.Logic.Services;
 using Conflux.Domain.Session;
 using Microsoft.AspNetCore.Http;
@@ -42,13 +43,8 @@ public class AuthorizationFilterTests : IAsyncAuthorizationFilter
             return;
 
         // Check user authentication
-        UserSession? userSession = await _userSessionService.GetUser();
-        if (userSession?.User is null)
-        {
-            context.Result = new UnauthorizedResult();
-            return;
-        }
-
+        User user = await _userSessionService.GetUser();
+        
         // Check route parameter for project ID
         RouteValueDictionary routeData = context.RouteData.Values;
         RouteParamNameAttribute? routeParamNameAttribute = endpoint?.Metadata.GetMetadata<RouteParamNameAttribute>();
@@ -65,7 +61,7 @@ public class AuthorizationFilterTests : IAsyncAuthorizationFilter
                 throw new ArgumentException("Project ID is not a valid GUID", nameof(projectIdString));
         }
 
-        Guid userId = userSession.User!.Id;
+        Guid userId = user.Id;
 
         // Check if user has the required role
         bool hasRole = await _accessControlService.UserHasRoleInProject(

--- a/Conflux.API.Tests/WebApplicationFactoryTests.cs
+++ b/Conflux.API.Tests/WebApplicationFactoryTests.cs
@@ -242,9 +242,11 @@ public class WebApplicationFactoryTests : WebApplicationFactory<Program>
 
             // Mock the user session service to return our test admin user
             Mock<IUserSessionService> mockUserSessionService = new();
-            mockUserSessionService.Setup(m => m.GetUser()).ReturnsAsync(new UserSession
+            
+            // Set up the test user and session
+            UserSession testSession = new UserSession
             {
-                User = testUser,
+                UserId = testUserId,
                 Collaborations =
                 [
                     new()
@@ -271,7 +273,11 @@ public class WebApplicationFactoryTests : WebApplicationFactory<Program>
                         ],
                     },
                 ],
-            });
+            };
+            
+            mockUserSessionService.Setup(m => m.GetSession()).ReturnsAsync(testSession);
+            
+            mockUserSessionService.Setup(m => m.GetUser()).ReturnsAsync(testUser);
 
             // Replace the actual service with our mock
             services.AddScoped<IUserSessionService>(_ => mockUserSessionService.Object);

--- a/Conflux.API/Controllers/ProjectsController.cs
+++ b/Conflux.API/Controllers/ProjectsController.cs
@@ -71,7 +71,7 @@ public class ProjectsController : ControllerBase
     [ProducesResponseType(typeof(List<TimelineItemResponseDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<TimelineItemResponseDTO>>> GetProjectTimeline([FromQuery] Guid id)
     {
-        UserSession? userSession = await _userSessionService.GetUser();
+        UserSession? userSession = await _userSessionService.GetSession();
         if (userSession is null)
             return Unauthorized();
         
@@ -93,7 +93,7 @@ public class ProjectsController : ControllerBase
     [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
     public async Task<ActionResult> ExportToCsv([FromQuery] ProjectCsvRequestDTO projectQueryDto)
     {
-        UserSession? userSession = await _userSessionService.GetUser();
+        UserSession? userSession = await _userSessionService.GetSession();
         if (userSession is null)
             return Unauthorized();
         
@@ -111,7 +111,7 @@ public class ProjectsController : ControllerBase
     [ProducesResponseType(typeof(List<ProjectResponseDTO>), StatusCodes.Status200OK)]
     public async Task<ActionResult<List<ProjectResponseDTO>>> GetAllProjects()
     {
-        UserSession? userSession = await _userSessionService.GetUser();
+        UserSession? userSession = await _userSessionService.GetSession();
         if (userSession is null)
             return Unauthorized();
         return await _projectsService.GetAllProjectsAsync();

--- a/Conflux.API/Filters/AccessControlFilter.cs
+++ b/Conflux.API/Filters/AccessControlFilter.cs
@@ -20,12 +20,7 @@ public class AccessControlFilter(
 {
     public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
     {
-        UserSession? userSession = await userSessionService.GetUser();
-        if (userSession?.User is null)
-        {
-            context.Result = new UnauthorizedResult();
-            return;
-        }
+        User user = await userSessionService.GetUser();
 
         RouteValueDictionary routeData = context.RouteData.Values;
         Endpoint? endpoint = context.HttpContext.GetEndpoint();
@@ -43,10 +38,8 @@ public class AccessControlFilter(
             if (!Guid.TryParse(projectIdString, out projectId))
                 throw new ArgumentException("Project ID is not a valid GUID", nameof(projectIdString));
         }
-
-        Guid userId = userSession.User!.Id;
-
-        bool hasRole = await accessControlService.UserHasRoleInProject(userId, projectId, userRoleType);
+        
+        bool hasRole = await accessControlService.UserHasRoleInProject(user.Id, projectId, userRoleType);
         if (!hasRole)
             throw new UnauthorizedAccessException("User does not have the required role in the project");
     }

--- a/Conflux.Data/ConfluxContext.cs
+++ b/Conflux.Data/ConfluxContext.cs
@@ -210,5 +210,5 @@ public class ConfluxContext : DbContext, IConfluxContext
         base.OnModelCreating(modelBuilder);
     }
 
-    public bool ShouldSeed() => Users.Find(UserSession.DevelopmentUserId) != null;
+    public bool ShouldSeed() => Users.AsNoTracking().Any(u => u.Id == UserSession.DevelopmentUserId);
 }

--- a/Conflux.Domain.Logic/Exceptions/UserNotFoundException.cs
+++ b/Conflux.Domain.Logic/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,26 @@
+// This program has been developed by students from the bachelor Computer Science at Utrecht
+// University within the Software Project course.
+// 
+// © Copyright Utrecht University (Department of Information and Computing Sciences)
+
+namespace Conflux.Domain.Logic.Exceptions;
+
+public class UserNotFoundException : Exception
+{
+    public UserNotFoundException() : base("User not found.")
+    {
+    }
+
+    public UserNotFoundException(string message) : base(message)
+    {
+    }
+    
+    public UserNotFoundException(Guid userId) 
+        : base($"User with ID {userId} not found.")
+    {
+    }
+
+    public UserNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Conflux.Domain.Logic/Services/AccessControlService.cs
+++ b/Conflux.Domain.Logic/Services/AccessControlService.cs
@@ -13,6 +13,7 @@ public class AccessControlService(ConfluxContext context) : IAccessControlServic
     public async Task<bool> UserHasRoleInProject(Guid userId, Guid projectId, UserRoleType roleType)
     {
         User? user = await context.Users
+            .AsNoTracking()
             .Include(u => u.Roles)
             .SingleOrDefaultAsync(u => u.Id == userId);
         if (user == null) return false;

--- a/Conflux.Domain.Logic/Services/AdminService.cs
+++ b/Conflux.Domain.Logic/Services/AdminService.cs
@@ -16,13 +16,11 @@ public class AdminService : IAdminService
 {
     private readonly ConfluxContext _context;
     private readonly IConfiguration _configuration;
-    private readonly IUserSessionService _userSessionService;
 
-    public AdminService(ConfluxContext context, IConfiguration configuration, IUserSessionService userSessionService)
+    public AdminService(ConfluxContext context, IConfiguration configuration)
     {
         _context = context;
         _configuration = configuration;
-        _userSessionService = userSessionService;
     }
 
     private UserResponseDTO MapUserToResponse(User user)
@@ -52,13 +50,6 @@ public class AdminService : IAdminService
     /// <inheritdoc />
     public async Task<List<UserResponseDTO>> GetUsersByQuery(string? query, bool adminsOnly)
     {
-        UserSession? userSession = await _userSessionService.GetUser();
-        if (userSession is null)
-            throw new UserNotAuthenticatedException();
-
-        if (userSession.User is null || userSession.User.PermissionLevel != PermissionLevel.SuperAdmin)
-            throw new UnauthorizedAccessException("You do not have permission to access this resource.");
-
         List<User> users = await _context.Users
             .AsNoTracking()
             .Include(u => u.Person)
@@ -75,22 +66,10 @@ public class AdminService : IAdminService
     /// <inheritdoc />
     public async Task<UserResponseDTO> SetUserPermissionLevel(Guid userId, PermissionLevel permissionLevel)
     {
-        UserSession? userSession = await _userSessionService.GetUser();
-        if (userSession is null)
-            throw new UserNotAuthenticatedException();
-
-        if (userSession.User is null || userSession.User.PermissionLevel != PermissionLevel.SuperAdmin)
-            throw new UnauthorizedAccessException("You do not have permission to access this resource.");
-        
-        if (permissionLevel == PermissionLevel.SuperAdmin)
-            throw new ArgumentException("Cannot set user permission level to SuperAdmin. This has to be done manually.");
-
-        User? user = await _context.Users
+        User user = await _context.Users
             .Include(u => u.Person)
-            .SingleOrDefaultAsync(u => u.Id == userId);
-        if (user is null)
-            throw new Exception($"User with ID {userId} not found.");
-
+            .SingleOrDefaultAsync(u => u.Id == userId) ?? throw new UserNotFoundException(userId);
+        
         user.PermissionLevel = permissionLevel;
         await _context.SaveChangesAsync();
 
@@ -102,41 +81,23 @@ public class AdminService : IAdminService
         Task.FromResult(_configuration.GetSection("Lectorates").Get<List<string>>() ?? []);
 
     /// <inheritdoc />
-    public async Task<List<string>> GetAvailableOrganisations()
-    {
-        UserSession? userSession = await _userSessionService.GetUser();
-        if (userSession is null)
-            throw new UserNotAuthenticatedException();
-        if (userSession.User is null || userSession.User.PermissionLevel != PermissionLevel.SuperAdmin)
-            throw new UnauthorizedAccessException("You do not have permission to access this resource.");
-
+    public async Task<List<string>> GetAvailableOrganisations() =>
         // get all projects with organisation set
-        return await _context.Projects
+        await _context.Projects
             .AsNoTracking()
             .Select(p => p.OwnerOrganisation!)
             .Where(o => !string.IsNullOrEmpty(o))
             .Distinct()
             .ToListAsync();
-    }
 
     /// <inheritdoc />
     public async Task<UserResponseDTO> AssignLectoratesToUser(Guid userId, List<string> lectorates)
     {
-        UserSession? userSession = _userSessionService.GetUser().Result;
-        if (userSession is null)
-            throw new UserNotAuthenticatedException();
-
-        if (userSession.User is null || userSession.User.PermissionLevel != PermissionLevel.SuperAdmin)
-            throw new UnauthorizedAccessException("You do not have permission to access this resource.");
-
-        User? user = _context.Users.
-            Include(u => u.Person)
-            .SingleOrDefault(u => u.Id == userId);
-        if (user is null)
-            throw new Exception($"User with ID {userId} not found.");
+        User user = await _context.Users
+            .Include(u => u.Person)
+            .SingleOrDefaultAsync(u => u.Id == userId) ?? throw new UserNotFoundException(userId);
 
         user.AssignedLectorates = lectorates;
-        _context.Users.Update(user);
         await _context.SaveChangesAsync();
 
         return MapUserToResponse(user);
@@ -145,21 +106,11 @@ public class AdminService : IAdminService
     /// <inheritdoc />
     public async Task<UserResponseDTO> AssignOrganisationsToUser(Guid userId, List<string> organisations)
     {
-        UserSession? userSession = _userSessionService.GetUser().Result;
-        if (userSession is null)
-            throw new UserNotAuthenticatedException();
-
-        if (userSession.User is null || userSession.User.PermissionLevel != PermissionLevel.SuperAdmin)
-            throw new UnauthorizedAccessException("You do not have permission to access this resource.");
-
-        User? user = _context.Users.
-            Include(u => u.Person)
-            .SingleOrDefault(u => u.Id == userId);
-        if (user is null)
-            throw new Exception($"User with ID {userId} not found.");
+        User user = await _context.Users
+            .Include(u => u.Person)
+            .SingleOrDefaultAsync(u => u.Id == userId) ?? throw new UserNotFoundException(userId);
 
         user.AssignedOrganisations = organisations;
-        _context.Users.Update(user);
         await _context.SaveChangesAsync();
 
         return MapUserToResponse(user);

--- a/Conflux.Domain.Logic/Services/IUserSessionService.cs
+++ b/Conflux.Domain.Logic/Services/IUserSessionService.cs
@@ -10,8 +10,8 @@ namespace Conflux.Domain.Logic.Services;
 
 public interface IUserSessionService
 {
-    Task<UserSession?> GetUser();
-    Task<UserSession?> UpdateUser();
+    Task<UserSession?> GetSession();
+    Task<User> GetUser();
     Task CommitUser(UserSession userSession);
     Task<UserSession?> SetUser(ClaimsPrincipal? claims);
     void ClearUser();

--- a/Conflux.Domain.Logic/Services/ProjectDescriptionsService.cs
+++ b/Conflux.Domain.Logic/Services/ProjectDescriptionsService.cs
@@ -66,18 +66,16 @@ public class ProjectDescriptionsService(
         context.ProjectDescriptions.Add(description);
         await context.SaveChangesAsync();
 
-        // Update project embedding asynchronously
-        _ = Task.Run(async () =>
+        try 
         {
-            try
-            {
-                await projectsService.UpdateProjectEmbeddingAsync(projectId);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to update embedding for project {ProjectId} after description creation", projectId);
-            }
-        });
+            // Update embedding directly instead of using Task.Run
+            await projectsService.UpdateProjectEmbeddingAsync(projectId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update embedding for project {ProjectId} after description creation", projectId);
+            // Continue despite embedding update failure
+        }
 
         return MapToDescriptionResponseDTO(description);
     }
@@ -94,18 +92,14 @@ public class ProjectDescriptionsService(
 
         await context.SaveChangesAsync();
 
-        // Update project embedding asynchronously
-        _ = Task.Run(async () =>
+        try
         {
-            try
-            {
-                await projectsService.UpdateProjectEmbeddingAsync(projectId);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to update embedding for project {ProjectId} after description update", projectId);
-            }
-        });
+            await projectsService.UpdateProjectEmbeddingAsync(projectId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update embedding for project {ProjectId} after description update", projectId);
+        }
 
         return MapToDescriptionResponseDTO(description);
     }

--- a/Conflux.Domain.Logic/Services/SessionMappingService.cs
+++ b/Conflux.Domain.Logic/Services/SessionMappingService.cs
@@ -277,6 +277,7 @@ public class SessionMappingService : ISessionMappingService
                 .SingleOrDefaultAsync(p => p.SCIMId == group.SCIMId);
 
             var users = await _context.Users
+                .AsNoTracking()
                 .Where(p => group.Members.Select(m => m.SCIMId).Contains(p.SCIMId))
                 .ToListAsync();
 

--- a/Conflux.Domain/Session/UserSession.cs
+++ b/Conflux.Domain/Session/UserSession.cs
@@ -13,10 +13,10 @@ public class UserSession
     public string GivenName { get; set; } = string.Empty;
     public string FamilyName { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
-    public User? User { get; set; }
+    public Guid UserId { get; set; }
     public List<Collaboration> Collaborations { get; set; } = [];
 
-    public static UserSession Development()
+    public static (UserSession, User) Development()
     {
         string sramId = DevelopmentUserId + "@sram.surf.nl";
         
@@ -44,14 +44,14 @@ public class UserSession
         // Set bidirectional reference
         developmentPerson.User = developmentUser;
         
-        return new()
+        return (new()
         {
             SRAMId = sramId,
             Name = "Development User",
             GivenName = "Development",
             FamilyName = "User",
             Email = "development@sram.surf.nl",
-            User = developmentUser,
+            UserId = DevelopmentUserId,
             Collaborations =
             [
                 new()
@@ -88,6 +88,6 @@ public class UserSession
                     ],
                 },
             ],
-        };
+        }, developmentUser);
     }
 }

--- a/Conflux.Integrations.NWOpen/NwOpenMapper.cs
+++ b/Conflux.Integrations.NWOpen/NwOpenMapper.cs
@@ -275,7 +275,7 @@ public static class NwOpenMapper
         else
         {
             // Create a new development user and add to our list
-            devUser = UserSession.Development().User!;
+            devUser = UserSession.Development().Item2;
             Users.Add(devUser);
             People.Add(devUser.Person!);
         }


### PR DESCRIPTION
## YouTrack tasks
CX-339

## Description
- We should not store the user in the session and then trust it to be the most recent data.


## Additional Information

[Any additional information that reviewers should be aware of.]

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
- [x] All endpoints have the proper access control attributes
